### PR TITLE
fix: Fixes possible NP when writing text and currLead is null

### DIFF
--- a/src/main/java/com/itextpdf/pdfcleanup/TextPositioning.java
+++ b/src/main/java/com/itextpdf/pdfcleanup/TextPositioning.java
@@ -167,8 +167,9 @@ class TextPositioning {
     private void writePositioningOperator(PdfCanvas canvas) {
         if (firstPositioningOperands != null) {
             if ("T*".equals(prevOperator)) {
-                if (canvas.getGraphicsState().getLeading() != currLeading) {
-                    canvas.setLeading((float) currLeading);
+                float currLead = this.getCurrLeading();
+                if (canvas.getGraphicsState().getLeading() != currLead) {
+                    canvas.setLeading(currLead);
                 }
             }
             PdfCleanUpProcessor.writeOperands(canvas, firstPositioningOperands);
@@ -184,8 +185,9 @@ class TextPositioning {
         CanvasGraphicsState canvasGs = canvas.getGraphicsState();
         boolean newLineShowText = "'".equals(operator) || "\"".equals(operator);
         if (newLineShowText) {
-            if (canvasGs.getLeading() != currLeading) {
-                canvas.setLeading((float) currLeading);
+            float currLead = this.getCurrLeading();
+            if (canvasGs.getLeading() != currLead) {
+                canvas.setLeading((float) currLead);
             }
             // after new line operator, removed text shift doesn't matter
             removedTextShift = null;


### PR DESCRIPTION
- This case happened when redacting some test PDFS, using the getter fixes the problem in this kind of use cases.